### PR TITLE
fix: reset pagination when search filters change

### DIFF
--- a/src/features/search/containers/SearchBarAndTagContainer.tsx
+++ b/src/features/search/containers/SearchBarAndTagContainer.tsx
@@ -40,6 +40,7 @@ export const SearchBarAndTagContainer: React.FC = () => {
   useEffect(() => {
     const timeoutId = setTimeout(() => {
       searchResources(searchTerm, selectedTags);
+      setCurrentPage(1);
     }, 300); // 300ms debounce delay
 
     return () => clearTimeout(timeoutId);
@@ -55,6 +56,7 @@ export const SearchBarAndTagContainer: React.FC = () => {
         searchResources(searchTerm, newTags);
         return newTags;
       });
+      setCurrentPage(1);
     },
     [searchTerm, searchResources]
   );


### PR DESCRIPTION
When applying search terms or tag filters while on pages other than
the first page, the results were showing "No Resources Found" because
the pagination state wasn't being reset. This fix ensures the current
page returns to page 1 whenever filters are modified.